### PR TITLE
bubbles: add `aiofiles` to python venv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiofiles
 appdirs==1.4.4
 asgiref==3.4.1
 black==21.7b0


### PR DESCRIPTION
```
py39 run-test: commands[0] | pytest backend/
ImportError while loading conftest '/home/mgfritch/src/github.com/mgfritch/bubbles/backend/tests/conftest.py'.
__init__.py:14: in <module>
    from .module import BubblesModule
module.py:19: in <module>
    from fastapi.staticfiles import StaticFiles
.tox/py39/lib/python3.9/site-packages/fastapi/staticfiles.py:1: in <module>
    from starlette.staticfiles import StaticFiles as StaticFiles  # noqa
.tox/py39/lib/python3.9/site-packages/starlette/staticfiles.py:7: in <module>
    from aiofiles.os import stat as aio_stat
E   ModuleNotFoundError: No module named 'aiofiles'
ERROR: InvocationError for command /home/mgfritch/src/github.com/mgfritch/bubbles/.tox/py39/bin/pytest backend/ (exited with code 4)
```

Signed-off-by: Michael Fritch <mfritch@suse.com>