### PR TITLE
bubbles: deploy: use pacific-based, python3.8 images

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -23,6 +23,24 @@ Finally, we'll need to serve the built image from a local registry so that
 [1]: https://docs.ceph.com/en/latest/dev/cephadm/developing-cephadm/#kcli-a-virtualization-management-tool-to-make-easy-orchestrators-development
 
 
+### NOTE BEFORE
+
+Because libpython3.6 does not play well with asyncio's event loop, for reasons
+unknown at the time, we are limited to running containers with binaries built
+and linked against libpython3.8+.
+
+Unfortunately this means that we can't be using the upstream containers as
+base for our images, since these are based on a python 3.6 release.
+
+We have thus moved to containers we know are built against python 3.8, coming
+from opensuse's registry. However, these are built solely for Pacific, instead
+of following Ceph's master branch.
+
+Until this is ironed out, we are bound by the Pacific release. This also means
+that we will be grabbing a Pacific `cephadm` from the upstream repositories,
+instead of relying on the currently available version in the developer's
+machine. This is a nasty kludge, but will get us through this dark period.
+
 ### libvirt
 
 Our VMs, deployed with `kcli`, will be run with `libvirt`. Thus, one needs

--- a/deploy/container/Dockerfile
+++ b/deploy/container/Dockerfile
@@ -1,5 +1,6 @@
-FROM quay.ceph.io/ceph-ci/ceph:master
+FROM registry.opensuse.org/opensuse/ceph/ceph:latest
 LABEL maintainer="Joao Eduardo Luis <joao@suse.com>"
 
-RUN pip3 install fastapi uvicorn aiofiles
+RUN zypper install -y python38-pip
+RUN pip install fastapi uvicorn aiofiles
 

--- a/deploy/plan/bootstrap-cluster.sh
+++ b/deploy/plan/bootstrap-cluster.sh
@@ -3,10 +3,20 @@
 export PATH=/root/bin:$PATH
 mkdir /root/bin
 {% if ceph_dev_folder is defined %}
-  cp /mnt/{{ ceph_dev_folder }}/src/cephadm/cephadm /root/bin/cephadm
+  # NOTE: we need a pacific cephadm for now, regardless of what version the
+  # developer is working against.
+  # cp /mnt/{{ ceph_dev_folder }}/src/cephadm/cephadm /root/bin/cephadm
+  pushd /root/bin
+  curl --silent --remote-name \
+    --location \
+    https://raw.githubusercontent.com/ceph/ceph/pacific/src/cephadm/cephadm
+  popd
 {% else %}
-  cd /root/bin
-  curl --silent --remote-name --location https://raw.githubusercontent.com/ceph/ceph/master/src/cephadm/cephadm
+  pushd /root/bin
+  curl --silent --remote-name \
+    --location \
+    https://raw.githubusercontent.com/ceph/ceph/pacific/src/cephadm/cephadm
+  popd
 {% endif %}
 chmod +x /root/bin/cephadm
 mkdir -p /etc/ceph
@@ -18,9 +28,22 @@ mon_ip=$(ifconfig eth0  | grep 'inet ' | awk '{ print $2}')
   cephadm --image {{ registry }}/ceph/bubbles:master \
     bootstrap \
     --skip-pull \
-    --mon-ip $mon_ip --initial-dashboard-password {{ admin_password }} --allow-fqdn-hostname --dashboard-password-noupdate --shared_ceph_folder /mnt/{{ ceph_dev_folder }}
+    --mon-ip $mon_ip \
+    --initial-dashboard-password {{ admin_password }} \
+    --allow-fqdn-hostname \
+    --dashboard-password-noupdate \
+    --shared_ceph_folder /mnt/{{ ceph_dev_folder }}
 {% else %}
-  cephadm bootstrap --mon-ip $mon_ip --initial-dashboard-password {{ admin_password }} --allow-fqdn-hostname --dashboard-password-noupdate
+  podman pull --tls-verify=false \
+    docker://{{ registry }}/ceph/bubbles:master
+
+  cephadm --image {{registry}}/ceph/bubbles:master \
+    bootstrap \
+    --skip-pull \
+    --mon-ip $mon_ip \
+    --initial-dashboard-password {{ admin_password }} \
+    --allow-fqdn-hostname \
+    --dashboard-password-noupdate
 {% endif %}
 fsid=$(cat /etc/ceph/ceph.conf | grep fsid | awk '{ print $3}')
 {% for number in range(1, nodes) %}


### PR DESCRIPTION
## Why?

Because the upstream's Ceph container images are built against python 3.6, and libpython3.6 seems to have issues with asyncio event loops that do not exist, by default, with libpython3.8.

Sticking to pacific is a workaround, meant to allow development to progress while we figure out how to have python3.8-based master images.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>