### PR TITLE
bubbles: deploy: follow Ceph's master

### DIFF
--- a/deploy/container/Dockerfile
+++ b/deploy/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.opensuse.org/opensuse/ceph/ceph:latest
+FROM registry.opensuse.org/filesystems/ceph/master/upstream/images/opensuse/ceph/ceph:latest
 LABEL maintainer="Joao Eduardo Luis <joao@suse.com>"
 
 RUN zypper install -y python38-pip

--- a/deploy/plan/bootstrap-cluster.sh
+++ b/deploy/plan/bootstrap-cluster.sh
@@ -3,19 +3,12 @@
 export PATH=/root/bin:$PATH
 mkdir /root/bin
 {% if ceph_dev_folder is defined %}
-  # NOTE: we need a pacific cephadm for now, regardless of what version the
-  # developer is working against.
-  # cp /mnt/{{ ceph_dev_folder }}/src/cephadm/cephadm /root/bin/cephadm
-  pushd /root/bin
-  curl --silent --remote-name \
-    --location \
-    https://raw.githubusercontent.com/ceph/ceph/pacific/src/cephadm/cephadm
-  popd
+  cp /mnt/{{ ceph_dev_folder }}/src/cephadm/cephadm /root/bin/cephadm
 {% else %}
   pushd /root/bin
   curl --silent --remote-name \
     --location \
-    https://raw.githubusercontent.com/ceph/ceph/pacific/src/cephadm/cephadm
+    https://raw.githubusercontent.com/ceph/ceph/master/src/cephadm/cephadm
   popd
 {% endif %}
 chmod +x /root/bin/cephadm


### PR DESCRIPTION
We now have a container build with python3.8 binaries, so we can go back
to following master instead of being stuck with pacific.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>