### PR TITLE
Backend: Make Bubbles not so chatty

### DIFF
--- a/module.py
+++ b/module.py
@@ -97,4 +97,5 @@ class BubblesModule(MgrModule):
             return
 
     def notify(self, notify_type: str, notify_id: str) -> None:
-        self.log.debug(f"recv notify {notify_type}")
+        # self.log.debug(f"recv notify {notify_type}")
+        pass


### PR DESCRIPTION
Do not log 'notify' calls, otherwise the log is spammed with multiple entries every second.

Signed-off-by: Volker Theile <vtheile@suse.com>