### PR TITLE
bubbles: mock `mgr_module` during pytest

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from unittest import mock
+
+sys.modules['mgr_module'] = mock.MagicMock()


### PR DESCRIPTION
```
py3 run-test: commands[0] | pytest backend/
ImportError while loading conftest '/home/mgfritch/src/github.com/mgfritch/bubbles/backend/tests/conftest.py'.
__init__.py:14: in <module>
    from .module import BubblesModule
module.py:25: in <module>
    from mgr_module import MgrModule
E   ModuleNotFoundError: No module named 'mgr_module'
ERROR: InvocationError for command /home/mgfritch/src/github.com/mgfritch/bubbles/.tox/py3/bin/pytest backend/ (exited with code 4)
```

Signed-off-by: Michael Fritch <mfritch@suse.com>