### PR TITLE
bubbles: clean-up type checking

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -16,7 +16,7 @@ from bubbles.backend.auth import JWT, JWTDenyList, JWTMgr
 
 
 class JWTAuthSchema(OAuth2PasswordBearer):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__(tokenUrl="auth/login")
 
     async def __call__(self, request: Request) -> Optional[JWT]:  # type: ignore[override]

--- a/backend/api/host.py
+++ b/backend/api/host.py
@@ -8,6 +8,7 @@
 from typing import List
 
 from fastapi import APIRouter, Depends, Request, Response
+from typing import Callable
 
 from bubbles.bubbles import Bubbles
 from bubbles.backend.api import jwt_auth_scheme
@@ -18,7 +19,7 @@ router = APIRouter(prefix="/host", tags=["host"])
 
 @router.get("/", name="Get list of hosts", response_model=List[HostModel])
 async def get_hosts(
-    request: Request, _=Depends(jwt_auth_scheme)
+    request: Request, _: Callable = Depends(jwt_auth_scheme)
 ) -> List[HostModel]:
     bubbles: Bubbles = request.app.state.bubbles
     assert bubbles.ctrls.rest_api_proxy is not None

--- a/backend/api/status.py
+++ b/backend/api/status.py
@@ -6,6 +6,7 @@
 # version 2.1 of the License, or (at your option) any later version.
 #
 from fastapi import APIRouter, Depends, Request
+from typing import Callable
 
 from bubbles.bubbles import Bubbles
 from bubbles.backend.api import jwt_auth_scheme
@@ -16,7 +17,7 @@ router = APIRouter(prefix="/status", tags=["status"])
 
 @router.get("/", name="Get the status information", response_model=StatusModel)
 async def get_status(
-    request: Request, _=Depends(jwt_auth_scheme)
+    request: Request, _: Callable = Depends(jwt_auth_scheme)
 ) -> StatusModel:
     bubbles: Bubbles = request.app.state.bubbles
     assert bubbles.ctrls.rest_api_proxy is not None

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -8,6 +8,7 @@
 from typing import List
 
 from fastapi import APIRouter, Depends, Request, Response
+from typing import Callable
 
 from bubbles.bubbles import Bubbles
 from bubbles.backend.api import jwt_auth_scheme
@@ -18,7 +19,7 @@ router = APIRouter(prefix="/users", tags=["users"])
 
 @router.get("/", name="Get list of users", response_model=List[UserModel])
 async def get_users(
-    request: Request, _=Depends(jwt_auth_scheme)
+    request: Request, _: Callable = Depends(jwt_auth_scheme)
 ) -> List[UserModel]:
     bubbles: Bubbles = request.app.state.bubbles
     assert bubbles.ctrls.rest_api_proxy is not None

--- a/backend/auth.py
+++ b/backend/auth.py
@@ -51,7 +51,7 @@ class JWTMgr:
         )
         return encoded_token
 
-    def get_raw_access_token(self, token, verify=True) -> JWT:
+    def get_raw_access_token(self, token: str, verify: bool = True) -> JWT:
         options = {}
         if not verify:
             options = {"verify_signature": False}

--- a/backend/config.py
+++ b/backend/config.py
@@ -20,7 +20,7 @@ class Config:
             self._config: ConfigModel = ConfigModel(version=1)
             self.save()
         else:
-            self._config: ConfigModel = ConfigModel.parse_obj(
+            self._config = ConfigModel.parse_obj(
                 json.loads(config_options))
 
     def save(self) -> None:

--- a/backend/controllers/rest_api_proxy.py
+++ b/backend/controllers/rest_api_proxy.py
@@ -10,7 +10,7 @@ import httpx
 
 from fastapi import HTTPException
 from pydantic import BaseModel, Field
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from mgr_module import MgrModule
 
@@ -67,7 +67,13 @@ class RestApiProxyController:
         self.request("POST", "/api/auth/logout")
 
     def request(
-        self, method, path, params=None, data=None, json=None, verify=False
+        self,
+        method: str,
+        path: str,
+        params: httpx._types.QueryParamTypes = None,
+        data: httpx._types.RequestData = {},
+        json: Any = None,
+        verify: bool = False
     ) -> Dict:
         """
         Perform a request to the Dashboard REST API.

--- a/bubbles.py
+++ b/bubbles.py
@@ -44,7 +44,7 @@ class Bubbles:
         return self._ctrls
 
     @property
-    def mgr(self):
+    def mgr(self) -> MgrModule:
         return self._mgr
 
     @property


### PR DESCRIPTION
fix various mypy errors introduced in the last few PRs:

```
mypy run-test-pre: PYTHONHASHSEED='117182252'
mypy run-test: commands[0] | mypy --config-file=mypy.ini -m bubbles
../bubbles/bubbles.py:13: note: In module imported here,
../bubbles/module.py:26: note: ... from here,
../bubbles/__init__.py:14: note: ... from here:
../bubbles/backend/config.py: note: In member "__init__" of class "Config":
../bubbles/backend/config.py:23: error: Attribute "_config" already defined on line 20
../bubbles/backend/controllers/ctrls.py:14: note: In module imported here,
../bubbles/bubbles.py:14: note: ... from here,
../bubbles/module.py:26: note: ... from here,
../bubbles/__init__.py:14: note: ... from here:
../bubbles/backend/controllers/rest_api_proxy.py: note: In member "request" of class "RestApiProxyController":
../bubbles/backend/controllers/rest_api_proxy.py:69: error: Function is missing a type annotation for one or more arguments
../bubbles/backend/api/__init__.py:15: note: In module imported here,
../bubbles/module.py:27: note: ... from here,
../bubbles/__init__.py:14: note: ... from here:
../bubbles/backend/auth.py: note: In member "get_raw_access_token" of class "JWTMgr":
../bubbles/backend/auth.py:54: error: Function is missing a type annotation for one or more arguments
../bubbles/module.py:26: note: In module imported here,
../bubbles/__init__.py:14: note: ... from here:
../bubbles/bubbles.py: note: In member "mgr" of class "Bubbles":
../bubbles/bubbles.py:47: error: Function is missing a return type annotation
../bubbles/module.py:27: note: In module imported here,
../bubbles/__init__.py:14: note: ... from here:
../bubbles/backend/api/__init__.py: note: In member "__init__" of class "JWTAuthSchema":
../bubbles/backend/api/__init__.py:19: error: Function is missing a return type annotation
../bubbles/backend/api/__init__.py:19: note: Use "-> None" if function does not return a value
../bubbles/module.py:27: note: In module imported here,
../bubbles/__init__.py:14: note: ... from here:
../bubbles/backend/api/user.py: note: In function "get_users":
../bubbles/backend/api/user.py:20: error: Function is missing a type annotation for one or more arguments
../bubbles/module.py:27: note: In module imported here,
../bubbles/__init__.py:14: note: ... from here:
../bubbles/backend/api/status.py: note: In function "get_status":
../bubbles/backend/api/status.py:18: error: Function is missing a type annotation for one or more arguments
../bubbles/module.py:27: note: In module imported here,
../bubbles/__init__.py:14: note: ... from here:
../bubbles/backend/api/host.py: note: In function "get_hosts":
../bubbles/backend/api/host.py:20: error: Function is missing a type annotation for one or more arguments
Found 8 errors in 8 files (checked 1 source file)
```

Signed-off-by: Michael Fritch mfritch@suse.com