### PR TITLE
frontend: Simplify wording in services page

### DIFF
--- a/frontend/src/app/pages/services-page/services-page.component.ts
+++ b/frontend/src/app/pages/services-page/services-page.component.ts
@@ -153,15 +153,23 @@ export class ServicesPageComponent {
                         name: 'available',
                         label: TEXT('Overall Capacity'),
                         value: stats.available,
-                        hint: TEXT('The overall available capacity in this cluster.'),
+                        hint: TEXT('The overall available capacity.'),
                         readonly: true
                       },
                       {
                         type: 'binary',
                         name: 'allocated',
-                        label: TEXT('Allocated Capacity'),
+                        label: TEXT('Used Capacity'),
                         value: stats.allocated,
-                        hint: TEXT('The currently allocated capacity in this cluster.'),
+                        hint: TEXT('The currently used capacity.'),
+                        readonly: true
+                      },
+                      {
+                        type: 'binary',
+                        name: 'free',
+                        label: TEXT('Free Capacity'),
+                        value: stats.unallocated,
+                        hint: TEXT('The currently free capacity.'),
                         readonly: true
                       }
                     ]


### PR DESCRIPTION
- Use 'Used' instead of 'Allocated'
- Use 'Free' instead of 'Unallocated'

![Peek 2021-10-01 13-30](https://user-images.githubusercontent.com/1897962/135613126-4e6ef6e9-38b3-4cf3-94a3-a137ca005e97.gif)

Signed-off-by: Volker Theile <vtheile@suse.com>