### PR TITLE
Simple extension mechanism

### DIFF
--- a/extras/helloworld/__init__.py
+++ b/extras/helloworld/__init__.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/hello")
+
+
+@router.get("/world", name="Hello World!")
+async def hello_world():
+    return "Hello World!"
+
+
+def init(app, api):
+    app.include_router(router)


### PR DESCRIPTION
Add simple namespace-based extension mechanism. Loads modules in the
bubbles.extras namespace and calls init(..) during bubbles initialization.

The code doesn't bother with types and defining a contract between extensions and main app, something the non-RFC should do.

To move forward I suggest we start with something as simple as this, add what we need when work on extras starts and refactor once we know more about the extra modules needs.

Qs Extension contract:
- Do we need more live cycle hooks (is init enough)? 
- Any preference on the extra module entry point? The RFC gets some FastAPI objects, we probably want a Bubbles object here as well.

Thoughts?

Related docs:
https://packaging.python.org/guides/creating-and-discovering-plugins/

Signed-off-by: Marcel Lauhoff <marcel.lauhoff@suse.com>