### PR TITLE
frontend: Improve widget component

### DIFF
--- a/frontend/src/app/shared/components/widget/widget.component.html
+++ b/frontend/src/app/shared/components/widget/widget.component.html
@@ -1,4 +1,5 @@
-<div class="card cb-dashboard-widget {{ status }}">
+<div class="card cb-dashboard-widget status {{ status }}"
+     [ngClass]="{'error': error}">
   <div class="card-body">
     <div class="card-title"
          fxLayout="row"

--- a/frontend/src/app/shared/components/widget/widget.component.scss
+++ b/frontend/src/app/shared/components/widget/widget.component.scss
@@ -26,22 +26,24 @@ div.cb-dashboard-widget {
     }
   }
 
-  &.info {
-    box-shadow: 0 0 1px 1px $cb-color-info !important;
+  &.status.info {
+    box-shadow: 0 0 1px 1px $glass-color-info !important;
   }
 
-  &.success {
-    box-shadow: 0 0 1px 1px $cb-color-success !important;
+  &.status.success {
+    box-shadow: 0 0 1px 1px $glass-color-success !important;
   }
 
-  &.warning {
-    box-shadow: 0 0 1px 1px $cb-color-warning !important;
+  &.status.warning {
+    box-shadow: 0 0 1px 1px $glass-color-warning !important;
+  }
+
+  &.status.error {
+    box-shadow: 0 0 1px 1px $glass-color-danger !important;
   }
 
   &.error {
-    @extend .cb-color-theme-error;
-
-    box-shadow: 0 0 1px 1px $cb-color-danger !important;
+    @extend .glass-color-theme-error;
 
     .card-body {
       background-color: transparent;

--- a/frontend/src/app/shared/components/widget/widget.component.ts
+++ b/frontend/src/app/shared/components/widget/widget.component.ts
@@ -15,7 +15,8 @@ export enum WidgetHealthStatus {
   info = 'info',
   success = 'success',
   warning = 'warning',
-  error = 'error'
+  error = 'error',
+  unknown = 'unknown'
 }
 
 @Component({
@@ -72,7 +73,7 @@ export class WidgetComponent implements OnInit, OnDestroy {
             err.preventDefault();
           }
           this.loading = false;
-          this.status = WidgetHealthStatus.error;
+          this.status = WidgetHealthStatus.unknown;
           this.error = true;
           return EMPTY;
         }),


### PR DESCRIPTION
Set widget status to unknown instead of error in case of a failed API call.
This way we can separate a real error status from an connection error.

Signed-off-by: Volker Theile <vtheile@suse.com>