### PR TITLE
Frontend: Add storage utilization widget

### DIFF
--- a/frontend/src/app/core/dashboard/dashboard.module.ts
+++ b/frontend/src/app/core/dashboard/dashboard.module.ts
@@ -11,6 +11,7 @@ import { HealthDashboardWidgetComponent } from '~/app/core/dashboard/widgets/hea
 import { PerformanceBytesDashboardWidgetComponent } from '~/app/core/dashboard/widgets/performance-bytes-dashboard-widget/performance-bytes-dashboard-widget.component';
 import { PerformanceOperationsDashboardWidgetComponent } from '~/app/core/dashboard/widgets/performance-operations-dashboard-widget/performance-operations-dashboard-widget.component';
 import { ServicesDashboardWidgetComponent } from '~/app/core/dashboard/widgets/services-dashboard-widget/services-dashboard-widget.component';
+import { StorageUtilizationDashboardWidgetComponent } from '~/app/core/dashboard/widgets/storage-utilization-dashboard-widget/storage-utilization-dashboard-widget.component';
 import { SharedModule } from '~/app/shared/shared.module';
 
 @NgModule({
@@ -19,14 +20,16 @@ import { SharedModule } from '~/app/shared/shared.module';
     HealthDashboardWidgetComponent,
     ServicesDashboardWidgetComponent,
     PerformanceBytesDashboardWidgetComponent,
-    PerformanceOperationsDashboardWidgetComponent
+    PerformanceOperationsDashboardWidgetComponent,
+    StorageUtilizationDashboardWidgetComponent
   ],
   exports: [
     EventsDashboardWidgetComponent,
     HealthDashboardWidgetComponent,
     ServicesDashboardWidgetComponent,
     PerformanceBytesDashboardWidgetComponent,
-    PerformanceOperationsDashboardWidgetComponent
+    PerformanceOperationsDashboardWidgetComponent,
+    StorageUtilizationDashboardWidgetComponent
   ],
   imports: [
     CommonModule,

--- a/frontend/src/app/core/dashboard/widgets/performance-bytes-dashboard-widget/performance-bytes-dashboard-widget.component.ts
+++ b/frontend/src/app/core/dashboard/widgets/performance-bytes-dashboard-widget/performance-bytes-dashboard-widget.component.ts
@@ -65,14 +65,14 @@ export class PerformanceBytesDashboardWidgetComponent {
         name: `${TEXT('Read')}: ${bytesToSize(status.pgmap.read_bytes_sec)}/s`,
         value: status.pgmap.read_bytes_sec,
         itemStyle: {
-          color: '#f58b1f'
+          color: '#009ccc'
         }
       },
       {
         name: `${TEXT('Write')}: ${bytesToSize(status.pgmap.write_bytes_sec)}/s`,
         value: status.pgmap.write_bytes_sec,
         itemStyle: {
-          color: '#009ccc'
+          color: '#f58b1f'
         }
       }
     ]);

--- a/frontend/src/app/core/dashboard/widgets/performance-operations-dashboard-widget/performance-operations-dashboard-widget.component.ts
+++ b/frontend/src/app/core/dashboard/widgets/performance-operations-dashboard-widget/performance-operations-dashboard-widget.component.ts
@@ -60,14 +60,14 @@ export class PerformanceOperationsDashboardWidgetComponent {
         name: `${TEXT('Read')}: ${status.pgmap.read_op_per_sec}/s`,
         value: status.pgmap.read_op_per_sec,
         itemStyle: {
-          color: '#f58b1f'
+          color: '#009ccc'
         }
       },
       {
         name: `${TEXT('Write')}: ${status.pgmap.write_op_per_sec}/s`,
         value: status.pgmap.write_op_per_sec,
         itemStyle: {
-          color: '#009ccc'
+          color: '#f58b1f'
         }
       }
     ]);

--- a/frontend/src/app/core/dashboard/widgets/storage-utilization-dashboard-widget/storage-utilization-dashboard-widget.component.html
+++ b/frontend/src/app/core/dashboard/widgets/storage-utilization-dashboard-widget/storage-utilization-dashboard-widget.component.html
@@ -1,0 +1,10 @@
+<cb-widget [loadData]="loadData.bind(this)"
+           widgetTitle="{{ 'Storage Utilization' | translate }}"
+           [setStatus]="setHealthStatusIndicator.bind(this)"
+           (loadDataEvent)="updateData($event)">
+  <div class="cb-storage-stats-dashboard-widget d-flex align-items-center justify-content-center"
+       echarts
+       [initOpts]="initOpts"
+       [options]="options">
+  </div>
+</cb-widget>

--- a/frontend/src/app/core/dashboard/widgets/storage-utilization-dashboard-widget/storage-utilization-dashboard-widget.component.scss
+++ b/frontend/src/app/core/dashboard/widgets/storage-utilization-dashboard-widget/storage-utilization-dashboard-widget.component.scss
@@ -1,0 +1,5 @@
+.cb-storage-stats-dashboard-widget {
+  max-height: 130px;
+  min-height: 130px;
+  overflow: hidden;
+}

--- a/frontend/src/app/core/dashboard/widgets/storage-utilization-dashboard-widget/storage-utilization-dashboard-widget.component.spec.ts
+++ b/frontend/src/app/core/dashboard/widgets/storage-utilization-dashboard-widget/storage-utilization-dashboard-widget.component.spec.ts
@@ -1,0 +1,28 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { DashboardModule } from '~/app/core/dashboard/dashboard.module';
+import { TestingModule } from '~/app/testing.module';
+
+import { StorageUtilizationDashboardWidgetComponent } from './storage-utilization-dashboard-widget.component';
+
+describe('StorageStatsDashboardWidgetComponent', () => {
+  let component: StorageUtilizationDashboardWidgetComponent;
+  let fixture: ComponentFixture<StorageUtilizationDashboardWidgetComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DashboardModule, TestingModule, TranslateModule.forRoot()]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StorageUtilizationDashboardWidgetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/core/dashboard/widgets/storage-utilization-dashboard-widget/storage-utilization-dashboard-widget.component.ts
+++ b/frontend/src/app/core/dashboard/widgets/storage-utilization-dashboard-widget/storage-utilization-dashboard-widget.component.ts
@@ -1,0 +1,90 @@
+import { Component } from '@angular/core';
+import { marker as TEXT } from '@biesbjerg/ngx-translate-extract-marker';
+import { EChartsOption } from 'echarts';
+import * as _ from 'lodash';
+import { Observable } from 'rxjs';
+
+import { bytesToSize } from '~/app/functions.helper';
+import { WidgetHealthStatus } from '~/app/shared/components/widget/widget.component';
+import { StorageService, StorageStats } from '~/app/shared/services/api/storage.service';
+
+@Component({
+  selector: 'cb-storage-utilization-dashboard-widget',
+  templateUrl: './storage-utilization-dashboard-widget.component.html',
+  styleUrls: ['./storage-utilization-dashboard-widget.component.scss']
+})
+export class StorageUtilizationDashboardWidgetComponent {
+  initOpts = {
+    height: 'auto',
+    width: 'auto'
+  };
+  options: EChartsOption = {
+    title: {
+      left: 'center',
+      top: '27%',
+      subtext: 'B/s',
+      itemGap: 0
+    },
+    tooltip: {
+      trigger: 'item',
+      position: 'inside',
+      formatter: '{b} ({d}%)'
+    },
+    legend: {
+      bottom: '0%',
+      left: 'center'
+    },
+    series: [
+      {
+        type: 'pie',
+        center: ['50%', '40%'],
+        radius: ['50%', '70%'],
+        label: {
+          show: false
+        },
+        data: []
+      }
+    ]
+  };
+
+  constructor(private storageService: StorageService) {}
+
+  loadData(): Observable<StorageStats> {
+    return this.storageService.stats();
+  }
+
+  updateData(stats: StorageStats) {
+    const total = _.split(bytesToSize(stats.total), ' ');
+    _.set(this.options, 'title.text', total[0]);
+    _.set(this.options, 'title.subtext', total[1]);
+    _.set(this.options, 'series[0].data', [
+      {
+        name: `${TEXT('Unallocated')}: ${bytesToSize(stats.unallocated)}`,
+        value: stats.unallocated,
+        itemStyle: {
+          color: '#009ccc'
+        }
+      },
+      {
+        name: `${TEXT('Allocated')}: ${bytesToSize(stats.allocated)}`,
+        value: stats.allocated,
+        itemStyle: {
+          color: '#f58b1f'
+        }
+      }
+    ]);
+    // Force change-detection to redraw the chart.
+    this.options = _.cloneDeep(this.options);
+  }
+
+  setHealthStatusIndicator(stats: StorageStats): WidgetHealthStatus {
+    const utilization = (100 / stats.total) * stats.allocated;
+    let healthStatus = WidgetHealthStatus.success;
+    if (utilization >= 70) {
+      healthStatus = WidgetHealthStatus.warning;
+    } else if (utilization >= 90) {
+      healthStatus = WidgetHealthStatus.error;
+    }
+    return healthStatus;
+  }
+}

--- a/frontend/src/app/pages/dashboard-page/dashboard-page.component.html
+++ b/frontend/src/app/pages/dashboard-page/dashboard-page.component.html
@@ -1,8 +1,9 @@
 <div class="cb-dashboard-page">
   <div class="row">
-    <cb-health-dashboard-widget class="widget col-12 col-md-4"></cb-health-dashboard-widget>
+    <cb-health-dashboard-widget class="widget col-12"></cb-health-dashboard-widget>
     <cb-performance-bytes-dashboard-widget class="widget col-12 col-md-4"></cb-performance-bytes-dashboard-widget>
     <cb-performance-operations-dashboard-widget class="widget col-12 col-md-4"></cb-performance-operations-dashboard-widget>
+    <cb-storage-utilization-dashboard-widget class="widget col-12 col-md-4"></cb-storage-utilization-dashboard-widget>
     <cb-events-dashboard-widget class="widget col-12 col-xxl-6"></cb-events-dashboard-widget>
     <cb-services-dashboard-widget class="widget col-12 col-xxl-6"></cb-services-dashboard-widget>
   </div>

--- a/frontend/src/app/shared/services/cluster-status.service.ts
+++ b/frontend/src/app/shared/services/cluster-status.service.ts
@@ -23,6 +23,8 @@ export class ClusterStatusService implements OnDestroy {
         switchMap(() =>
           this.clusterService.status().pipe(
             catchError((error) => {
+              // Forward error to subscribers.
+              this.statusSource.error(error);
               // Prevent default error handling.
               if (_.isFunction(error.preventDefault)) {
                 error.preventDefault();


### PR DESCRIPTION
![Bildschirmfoto vom 2021-10-18 16-13-30](https://user-images.githubusercontent.com/1897962/137748425-6b6b2f4f-a648-4355-8587-e9acd5b6b3af.png)

- Forward error in ClusterStatusService to subscribers.
- Switch colors of Read/Write in performance widgets.

Signed-off-by: Volker Theile <vtheile@suse.com>