### PR TITLE
Backend: Modify exception messages

### DIFF
--- a/backend/api/__init__.py
+++ b/backend/api/__init__.py
@@ -30,7 +30,7 @@ class JWTAuthSchema(OAuth2PasswordBearer):
             token = await super().__call__(request)
         if not token:
             raise HTTPException(
-                status_code=400, detail="Token missing from request"
+                status_code=400, detail="Token missing from request."
             )
 
         # Decode token and do the following checks:
@@ -44,7 +44,7 @@ class JWTAuthSchema(OAuth2PasswordBearer):
         deny_list.load()
         if deny_list.includes(raw_token):
             raise HTTPException(
-                status_code=401, detail="Token has been revoked"
+                status_code=401, detail="Token has been revoked."
             )
         return raw_token
 

--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -71,6 +71,6 @@ async def get_service(
         service_info = await bubbles.ctrls.services.get(name)
     except ServiceNotFoundError:
         raise HTTPException(
-            status.HTTP_404_NOT_FOUND, detail="Service does not exist"
+            status.HTTP_404_NOT_FOUND, detail="Service does not exist."
         )
     return service_info

--- a/backend/controllers/ceph/fs.py
+++ b/backend/controllers/ceph/fs.py
@@ -58,7 +58,7 @@ class CephFSController:
         for fs in self.ls():
             if name == fs.name:
                 return fs
-        raise NotFound(f"unknown fs: {fs.name}")
+        raise NotFound(f"Unknown file system: {fs.name}")
 
     def ls(self) -> List[CephFSListEntryModel]:
         try:

--- a/backend/controllers/ceph/nfs.py
+++ b/backend/controllers/ceph/nfs.py
@@ -95,7 +95,7 @@ class NFSCluster:
             if name == svc.name:
                 return svc
             assert False
-        raise NotFound(f"unknown nfs service name: {name}")
+        raise NotFound(f"Unknown NFS service name: {name}")
 
 
 class NFSExport:
@@ -133,7 +133,7 @@ class NFSExport:
         for export in self._ls(service_id, detail=True):
             if req.pseudo_path == export.pseudo:
                 return export
-        raise Error(f"failed to create nfs export")
+        raise Error(f"Failed to create NFS export.")
 
     def delete(self, service_id: str, export_id: int) -> None:
         export = self.get(service_id, export_id)
@@ -177,7 +177,7 @@ class NFSExport:
             if export_id == export.export_id:
                 return export
         raise NotFound(
-            f"nfs export {export_id} not found in nfs cluster {service_id}"
+            f"NFS export {export_id} not found in NFS cluster {service_id}."
         )
 
 

--- a/backend/controllers/ceph/osd.py
+++ b/backend/controllers/ceph/osd.py
@@ -41,7 +41,7 @@ class OSD:
         for pool in self.get_pools():
             if pool.pool_name == name:
                 return pool
-        raise NotFound(f"unknown pool: {name}")
+        raise NotFound(f"Unknown pool: {name}")
 
     def _pool_set(
         self,
@@ -63,7 +63,7 @@ class OSD:
         try:
             self._mgr.check_mon_command(cmd)
         except MonCommandFailed as e:
-            msg = f"unable to set {var} = {val} on pool {pool}: {e}"
+            msg = f"Unable to set {var} = {val} on pool {pool}: {e}"
             raise Error(msg)
 
     def set_pool(

--- a/backend/controllers/services.py
+++ b/backend/controllers/services.py
@@ -77,10 +77,10 @@ class ServicesController:
                 self._create_nfs(info)
             else:
                 raise NotImplementedError(
-                    f"unknown service backend: {info.backend}"
+                    f"Unknown service backend: {info.backend}"
                 )
         else:
-            raise NotImplementedError(f"unknwon service type: {info.type}")
+            raise NotImplementedError(f"Unknwon service type: {info.type}")
 
         self._services[info.name] = ServiceModel(info=info, pools=[])
         self._save()
@@ -92,7 +92,7 @@ class ServicesController:
         try:
             fs = cephfs.create(info.name)
         except ceph.fs.Error as e:
-            raise ServiceError("unable to create cephfs service") from e
+            raise ServiceError("Unable to create CephFS service.") from e
 
         # adjust the OSD pool size
         osd = ceph.osd.OSD(self._mgr)
@@ -131,7 +131,7 @@ class ServicesController:
             try:
                 nfs.cluster.create(nfs_svc_id, placement=nfs_svc_placement)
             except ceph.nfs.Error as e:
-                raise ServiceError(f"unable to create nfs service: {e}")
+                raise ServiceError(f"Unable to create nfs service: {e}")
 
         # export the root of the created cephfs service
         req = CephFSExportRequest(
@@ -145,7 +145,7 @@ class ServicesController:
                 req,
             )
         except ceph.nfs.Error as e:
-            raise ServiceError("unable to create nfs export")
+            raise ServiceError("Unable to create NFS export.")
 
         return True
 


### PR DESCRIPTION
- Make sure exception messages end with an dot. See best practices of MS .NET: https://docs.microsoft.com/en-us/dotnet/standard/exceptions/best-practices-for-exceptions#use-grammatically-correct-error-messages
- Make sure exception message starts with an uppercase word.

Signed-off-by: Volker Theile <vtheile@suse.com>