### PR TITLE
Frontend: Fix widget colors in case of success

### DIFF
--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -21,10 +21,6 @@
   color: $cb-color-white;
   background-color: $cb-color-danger;
 }
-.cb-color-theme-ok {
-  color: $cb-color-white;
-  background-color: $cb-color-success;
-}
 .cb-color-theme-warn {
   color: $cb-color-black;
   background-color: $cb-color-warning;
@@ -33,6 +29,7 @@
   color: $cb-color-white;
   background-color: $cb-color-info;
 }
+.cb-color-theme-ok,
 .cb-color-theme-success {
   color: $cb-color-white;
   background-color: $cb-color-success;


### PR DESCRIPTION
The health widget is using the success color schema if everything is ok. Previously the info schema was used. Now the inner part is using the same schema as the widget border which shows the status.

Signed-off-by: Volker Theile <vtheile@suse.com>