### PR TITLE
Frontend: Fix main layout

### DIFF
--- a/frontend/src/app/core/layouts/main-layout/main-layout.component.html
+++ b/frontend/src/app/core/layouts/main-layout/main-layout.component.html
@@ -1,11 +1,7 @@
 <block-ui>
   <div class="cb-main-layout"
-       fxLayout="row"
-       fxLayoutAlign="start stretch">
-    <div class="navigation"
-         [ngClass]="{'visible': navigationVisible}"
-         fxLayout="column"
-         fxLayoutAlign="start none">
+       [ngClass]="{'navigation-collapsed': navigationCollapsed}">
+    <aside class="navigation">
       <nav>
         <header fxLayout="row"
                 fxLayoutAlign="start center">
@@ -14,13 +10,10 @@
         </header>
         <cb-navigation-bar></cb-navigation-bar>
       </nav>
-    </div>
-    <div class="main"
-         fxFlex
-         fxLayout="column"
-         fxLayoutAlign="start none">
+    </aside>
+    <div class="main">
       <header>
-        <cb-top-bar (toggleNavigation)="navigationVisible = !navigationVisible"></cb-top-bar>
+        <cb-top-bar (toggleNavigation)="navigationCollapsed = !navigationCollapsed"></cb-top-bar>
       </header>
       <div class="content">
         <router-outlet></router-outlet>

--- a/frontend/src/app/core/layouts/main-layout/main-layout.component.scss
+++ b/frontend/src/app/core/layouts/main-layout/main-layout.component.scss
@@ -1,18 +1,29 @@
 @import 'styles.scss';
 
+$navigation-width: 15rem;
+
 .cb-main-layout {
-  height: 100%;
+  &.navigation-collapsed {
+    .navigation {
+      margin-left: -$navigation-width;
+    }
+
+    .main {
+      margin-left: 0;
+    }
+  }
 
   .navigation {
     background-color: $cb-color-menu-background;
-    margin-left: -15rem;
-    max-width: 15rem;
-    min-width: 15rem;
+    height: 100%;
+    left: 0;
+    margin-left: 0;
+    max-width: $navigation-width;
+    min-width: $navigation-width;
+    position: fixed;
+    top: 0;
     transition: all 0.3s;
-
-    &.visible {
-      margin-left: 0;
-    }
+    z-index: 1000;
 
     header {
       color: $cb-color-site-header-text;
@@ -47,8 +58,15 @@
   }
 
   .main {
+    margin-left: $navigation-width;
+    transition: all 0.3s;
+
     header {
       overflow-x: clip;
+      position: sticky;
+      top: 0;
+      width: 100%;
+      z-index: 1030;
 
       ::ng-deep .cb-top-bar {
         border-bottom: 1px solid $cb-color-gray-500;

--- a/frontend/src/app/core/layouts/main-layout/main-layout.component.ts
+++ b/frontend/src/app/core/layouts/main-layout/main-layout.component.ts
@@ -6,5 +6,5 @@ import { Component } from '@angular/core';
   styleUrls: ['./main-layout.component.scss']
 })
 export class MainLayoutComponent {
-  public navigationVisible = true;
+  public navigationCollapsed = false;
 }


### PR DESCRIPTION
The origin code causes some problems when the content area overflows. In that case the navigation area was not rendered correctly.

Before:
![Peek 2021-10-25 13-43](https://user-images.githubusercontent.com/1897962/138692391-8931d8c0-54a4-4990-bdc9-677d6e36281a.gif)

After:
![Peek 2021-10-25 13-42](https://user-images.githubusercontent.com/1897962/138692408-4cfcfba2-0711-45d0-a65b-27aaa38a53d4.gif)

Signed-off-by: Volker Theile <vtheile@suse.com>