### PR TITLE
deploy: obtain python packages from requirements

### DIFF
--- a/deploy/build-container.sh
+++ b/deploy/build-container.sh
@@ -118,7 +118,7 @@ ctr=$(sudo buildah from \
 [[ -z "${ctr}" ]] && err "error obtaining base container" && exit 1
 
 buildah run ${ctr} zypper install -y python38-pip || exit 1
-buildah run ${ctr} pip install fastapi uvicorn aiofiles || exit 1
+buildah run ${ctr} pip install $(cat ../requirements.txt) || exit 1
 
 mnt=$(sudo buildah mount ${ctr})
 [[ -z "${mnt}" ]] && err "error mounting container" && exit 1


### PR DESCRIPTION
Instead of having to update requirements each time we change them,
obtain them directly from 'requirements.txt'.

Signed-off-by: Joao Eduardo Luis \<joao@suse.com>