### PR TITLE
Frontend: Rename datatable column property 'unsortable' to 'sortable'

### DIFF
--- a/frontend/src/app/pages/users-page/users-page.component.ts
+++ b/frontend/src/app/pages/users-page/users-page.component.ts
@@ -53,7 +53,7 @@ export class UsersPageComponent {
       {
         name: '',
         prop: '',
-        unsortable: true,
+        sortable: false,
         cellTemplateName: DatatableCellTemplateName.actionMenu,
         cellTemplateConfig: this.onActionMenu.bind(this)
       }

--- a/frontend/src/app/shared/components/datatable/datatable.component.spec.ts
+++ b/frontend/src/app/shared/components/datatable/datatable.component.spec.ts
@@ -143,7 +143,7 @@ describe('DatatableComponent', () => {
   });
 
   it('should not sort not sortable columns', () => {
-    component.columns[0].unsortable = true;
+    component.columns[0].sortable = false;
     fixture.detectChanges();
     expect(component.sortHeader).toBe('bar');
     component.updateSorting(columns[0]);

--- a/frontend/src/app/shared/components/datatable/datatable.component.ts
+++ b/frontend/src/app/shared/components/datatable/datatable.component.ts
@@ -95,13 +95,16 @@ export class DatatableComponent implements OnInit, OnDestroy {
     if (this.columns) {
       // Sanitize the columns.
       _.forEach(this.columns, (column: DatatableColumn) => {
+        _.defaultsDeep(column, {
+          sortable: true
+        });
         if (_.isString(column.cellTemplateName)) {
           column.cellTemplate = this.cellTemplates[column.cellTemplateName];
           switch (column.cellTemplateName) {
             case 'actionMenu':
               column.name = '';
               column.prop = '_action'; // Add a none existing name here.
-              column.unsortable = true;
+              column.sortable = true;
               column.cols = 1;
               break;
           }
@@ -120,7 +123,7 @@ export class DatatableComponent implements OnInit, OnDestroy {
       });
     }
     this.sortableColumns = this.columns
-      .filter((c) => !c.unsortable)
+      .filter((c) => c.sortable === true)
       .map((c) => this.getSortProp(c));
     if (!this.sortHeader && this.sortableColumns.length > 0) {
       this.sortHeader = this.sortableColumns[0];
@@ -170,7 +173,7 @@ export class DatatableComponent implements OnInit, OnDestroy {
 
   setHeaderClasses(column: DatatableColumn): string {
     let css = column.css || '';
-    if (column.unsortable) {
+    if (column.sortable !== true) {
       return css;
     }
     css += ' sortable';

--- a/frontend/src/app/shared/models/datatable-column.type.ts
+++ b/frontend/src/app/shared/models/datatable-column.type.ts
@@ -48,6 +48,6 @@ export type DatatableColumn = {
   cellTemplateConfig?: any;
   cellTemplate?: TemplateRef<any>;
   pipe?: PipeTransform;
-  unsortable?: boolean;
+  sortable?: boolean; // Defaults to 'true'.
   align?: 'start' | 'center' | 'end';
 };


### PR DESCRIPTION
Naming this property 'sortable' is more common practice than 'unsortable'. The new name is also more intuitive.

Signed-off-by: Volker Theile <vtheile@suse.com>