### PR TITLE
Frontend: Hide datatable column action button

### DIFF
--- a/frontend/src/app/shared/components/datatable/datatable.component.html
+++ b/frontend/src/app/shared/components/datatable/datatable.component.html
@@ -119,7 +119,8 @@
              let-items="items"
              let-row="row">
   <div ngbDropdown>
-    <button class="btn"
+    <button *ngIf="items.length"
+            class="btn"
             title="{{ 'Actions' | translate }}"
             ngbDropdownToggle>
       <i class="mdi mdi-dots-vertical"></i>


### PR DESCRIPTION
Hide the action button if no menu entries are available.

Signed-off-by: Volker Theile <vtheile@suse.com>