### PR TITLE
Frontend: Improve datatable component

### DIFF
--- a/frontend/src/app/shared/components/datatable/datatable.component.html
+++ b/frontend/src/app/shared/components/datatable/datatable.component.html
@@ -22,7 +22,8 @@
         <div *ngIf="!(column.cellTemplateName || column.cellTemplate)">{{ renderCellValue(row, column) }}</div>
         <ng-template *ngIf="column.cellTemplate"
                      [ngTemplateOutlet]="column.cellTemplate"
-                     [ngTemplateOutletContext]="{ row: row, column: column, value: column.prop ? renderCellValue(row, column) : undefined }">
+                     [ngTemplateOutletContext]="{ row: row, column: column, value: column.prop ? renderCellValue(row, column) : undefined,
+                     disabled: column.prop ? renderCellDisabled(row, column) : false }">
         </ng-template>
       </td>
     </tr>
@@ -69,6 +70,16 @@
                   (pageChange)="reloadData()">
   </ngb-pagination>
 </div>
+
+<ng-template #rowSelectTpl
+             let-value="value"
+             let-row="row"
+             let-disabled="disabled">
+  <input type="checkbox"
+         [checked]="value"
+         [disabled]="disabled"
+         (change)="onSelectionChange($event, row)">
+</ng-template>
 
 <ng-template #yesNoIconTpl
              let-value="value">

--- a/frontend/src/app/shared/components/datatable/datatable.component.ts
+++ b/frontend/src/app/shared/components/datatable/datatable.component.ts
@@ -14,7 +14,10 @@ import * as _ from 'lodash';
 import { Subscription, timer } from 'rxjs';
 
 import { Icon } from '~/app/shared/enum/icon.enum';
-import { DatatableColumn } from '~/app/shared/models/datatable-column.type';
+import {
+  DatatableCellTemplateName,
+  DatatableColumn
+} from '~/app/shared/models/datatable-column.type';
 import { DatatableData } from '~/app/shared/models/datatable-data.type';
 
 export enum SortDirection {
@@ -34,6 +37,8 @@ export class DatatableComponent implements OnInit, OnDestroy {
   checkIconTpl?: TemplateRef<any>;
   @ViewChild('yesNoIconTpl', { static: true })
   yesNoIconTpl?: TemplateRef<any>;
+  @ViewChild('rowSelectTpl', { static: true })
+  rowSelectTpl?: TemplateRef<any>;
   @ViewChild('actionMenuTpl', { static: true })
   actionMenuTpl?: TemplateRef<any>;
   @ViewChild('mapTpl', { static: true })
@@ -73,8 +78,28 @@ export class DatatableComponent implements OnInit, OnDestroy {
   @Input()
   autoReload: number | boolean = 15000;
 
+  // Row property used as unique identifier for the shown data. Only used if
+  // the row selection is enabled. Will throw an error if property not found
+  // in given columns. Defaults to 'id'.
+  @Input()
+  identifier = 'id';
+
+  // Defines the following row selection types:
+  // none: no row selection
+  // single: allows single-select
+  // multi: allows multi-select
+  // Defaults to no row selection.
+  @Input()
+  selectionType: 'single' | 'multi' | 'none' = 'none';
+
+  @Input()
+  selected: Array<DatatableData> = [];
+
   @Output()
   loadData = new EventEmitter();
+
+  @Output()
+  selectionChange = new EventEmitter<DatatableData[]>();
 
   // Internal
   public icons = Icon;
@@ -110,6 +135,20 @@ export class DatatableComponent implements OnInit, OnDestroy {
           }
         }
       });
+
+      if (this.selectionType !== 'none') {
+        if (!_.find(this.columns, ['prop', this.identifier])) {
+          throw new Error(`Identifier "${this.identifier}" not found in defined columns.`);
+        }
+        this.columns.unshift({
+          name: '',
+          prop: '_rowSelect',
+          cellTemplate: this.cellTemplates[DatatableCellTemplateName.rowSelect],
+          cols: 1,
+          sortable: false,
+          align: 'center'
+        });
+      }
       // Get the columns to be displayed.
       this.displayedColumns = _.map(this.columns, 'prop');
     }
@@ -140,6 +179,7 @@ export class DatatableComponent implements OnInit, OnDestroy {
       icon: this.iconTpl!,
       checkIcon: this.checkIconTpl!,
       yesNoIcon: this.yesNoIconTpl!,
+      rowSelect: this.rowSelectTpl!,
       actionMenu: this.actionMenuTpl!,
       map: this.mapTpl!,
       join: this.joinTpl!,
@@ -152,7 +192,25 @@ export class DatatableComponent implements OnInit, OnDestroy {
     if (column.pipe && _.isFunction(column.pipe.transform)) {
       value = column.pipe.transform(value);
     }
+    if (column.prop === '_rowSelect') {
+      const item = _.find(this.selected, [this.identifier, row[this.identifier]]);
+      if (item) {
+        value = true;
+      }
+    }
     return value;
+  }
+
+  renderCellDisabled(row: DatatableData, column: DatatableColumn): any {
+    if (column.prop === '_rowSelect') {
+      if (this.selectionType === 'single') {
+        const item = _.find(this.selected, [this.identifier, row[this.identifier]]);
+        if (!item && this.selected.length > 0) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   updateSorting(c: DatatableColumn): void {
@@ -192,6 +250,7 @@ export class DatatableComponent implements OnInit, OnDestroy {
 
   reloadData(): void {
     this.loadData.emit();
+    this.updateSelection();
   }
 
   get filteredData(): DatatableData[] {
@@ -208,6 +267,29 @@ export class DatatableComponent implements OnInit, OnDestroy {
   onPageSizeChange(pageSize: number): void {
     this.pageSize = pageSize;
     this.reloadData();
+  }
+
+  onSelectionChange($event: any, row: DatatableData) {
+    if ($event.target.checked) {
+      this.selected.push(row);
+    } else {
+      const selectedIndex = _.findIndex(this.selected, [this.identifier, row[this.identifier]]);
+      if (selectedIndex >= 0) {
+        this.selected.splice(selectedIndex, 1);
+      }
+    }
+    this.selectionChange.emit(this.selected);
+  }
+
+  updateSelection(): void {
+    const updatedSelection: Array<DatatableData> = [];
+    this.selected.forEach((selectedItem) => {
+      const item = _.find(this.data, [this.identifier, selectedItem[this.identifier]]);
+      if (item) {
+        updatedSelection.push(item);
+      }
+    });
+    this.selected.splice(0, this.selected.length, ...updatedSelection);
   }
 
   private getSortProp(column: DatatableColumn): string {

--- a/frontend/src/app/shared/models/datatable-column.type.ts
+++ b/frontend/src/app/shared/models/datatable-column.type.ts
@@ -4,6 +4,7 @@ export enum DatatableCellTemplateName {
   icon = 'icon',
   checkIcon = 'checkIcon',
   yesNoIcon = 'yesNoIcon',
+  rowSelect = 'rowSelect',
   // Display a drop-down menu.
   // {
   //   ...


### PR DESCRIPTION
- Add ability to select rows (via checkbox). See https://github.com/aquarist-labs/aquarium/pull/756
- Make 'selected' as input attribute, thus the consuming component can access the data. Make 'updateSelection()' public to allow the consumer to update the selection if necessary.

Signed-off-by: Volker Theile <vtheile@suse.com>