### PR TITLE
deploy/build-container.sh: add extras directory to mkdist

### DIFF
--- a/deploy/build-container.sh
+++ b/deploy/build-container.sh
@@ -44,7 +44,7 @@ mkdist() {
   popd
 
   pushd ..
-  find backend -iname '*pycache*' -prune -false -o -iname '*.py' | \
+  find backend extras -iname '*pycache*' -prune -false -o -iname '*.py' | \
     xargs cp --parents --target-directory=deploy/dist
   cp LICENSE README.md COPYING bubbles.py module.py __init__.py deploy/dist/
   popd


### PR DESCRIPTION
Without this, `ceph mgr module enable bubbles` fails with "Error ENOENT: module 'bubbles' reports that it cannot run on the active manager daemon: No module named 'bubbles.extras' (pass --force to force enablement)".

Signed-off-by: Tim Serong <tserong@suse.com>