### PR TITLE
Announce the URI of the Bubbles UI

### DIFF
--- a/backend/typings/mgr_util.pyi
+++ b/backend/typings/mgr_util.pyi
@@ -1,0 +1,3 @@
+from typing import Optional
+
+def build_url(host: str, scheme: Optional[str] = ..., port: Optional[int] = ..., path: str = ...) -> str: ...


### PR DESCRIPTION
This can be listed via `ceph mgr services`.

```
[ceph: root@ceph-node-00 /]# ceph mgr services
{
    "dashboard": "https://192.168.122.32:8443/"
}
[ceph: root@ceph-node-00 /]# ceph mgr module enable bubbles
[ceph: root@ceph-node-00 /]# ceph mgr services
{
    "bubbles": "http://192.168.122.32:1337/",
    "dashboard": "https://192.168.122.32:8443/"
}
```

Signed-off-by: Volker Theile <vtheile@suse.com>