### PR TITLE
Use default datatable cell template for all columns that have not defined a specific template

### DIFF
--- a/frontend/src/app/shared/components/datatable/datatable.component.html
+++ b/frontend/src/app/shared/components/datatable/datatable.component.html
@@ -19,7 +19,10 @@
       <td *ngFor="let column of columns"
           [class]="column.css"
           [ngStyle]="{'text-align': !column?.align ? 'start' : column?.align}">
-        <div *ngIf="!(column.cellTemplateName || column.cellTemplate)">{{ renderCellValue(row, column) }}</div>
+        <ng-template *ngIf="!(column.cellTemplateName || column.cellTemplate)"
+                     [ngTemplateOutlet]="defaultTpl"
+                     [ngTemplateOutletContext]="{ value: renderCellValue(row, column) }">
+        </ng-template>
         <ng-template *ngIf="column.cellTemplate"
                      [ngTemplateOutlet]="column.cellTemplate"
                      [ngTemplateOutletContext]="{ row: row, column: column, value: column.prop ? renderCellValue(row, column) : undefined,
@@ -70,6 +73,11 @@
                   (pageChange)="reloadData()">
   </ngb-pagination>
 </div>
+
+<ng-template #defaultTpl
+             let-value="value">
+  <span [title]="value">{{ value }}</span>
+</ng-template>
 
 <ng-template #rowSelectTpl
              let-value="value"


### PR DESCRIPTION
This default cell template will display a tooltip which is useful if the cell content overlaps and is hidden via CSS 'overflow-x'.

![Bildschirmfoto von 2022-01-14 11-33-51](https://user-images.githubusercontent.com/1897962/149501747-2a729e9e-136c-4f10-8ff0-e9c345ff7806.png)

Signed-off-by: Volker Theile <vtheile@suse.com>