### PR TITLE
Build bubbles image on non SUSE distributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,14 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# Developer setup for non openSUSE based systems
+# Vagrant has to be used in order to build a bubbles image due to a
+# zypper openSUSE container bug, that won't be fixed.
+# https://bugzilla.opensuse.org/show_bug.cgi?id=1190670
+deploy/.vagrant/
+deploy/bubbles-image.tar
+deploy/load-image.sh
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -95,6 +95,24 @@ But this is a matter of taste, and it really doesn't matter in the end.
 
 ## Deployment
 
+
+### Get started
+
+To run a cluster with a newly build image, run the following command and follow the instructions in the script:
+
+```
+    # ./dev-env.sh rebuild
+```
+
+To recreate your cluster run the following command and follow the instructions in the script:
+
+```
+    # ./dev-env.sh recreate
+```
+
+Continue reading to learn whats happening behind the scenes.
+
+
 ### How it works
 
 In order to run a development version of Bubbles, we will rely on a slight hack
@@ -145,9 +163,25 @@ will execute `buildah` and `podman` commands.
     # ./build-container.sh
 ```
 
-Running `podman images` should now show a `localhost/opensuse/bubbles` image
+Running `sudo podman images` should now show a `localhost/opensuse/bubbles` image
 tagged with `master`. The name is relevant because that's the image name and
 tag we'll be pulling to deploy with `cephadm`.
+
+If you use a distribution thats not openSUSE based, you will hit
+[the bug where zypper fails](https://bugzilla.opensuse.org/show_bug.cgi?id=1190670).
+To overcome this bug, you have to use vagrant. You have to do the following steps
+in order to get the image.
+
+```
+    vagrant up
+    vagrant ssh
+```
+
+Inside the machine do the following:
+```
+    cd /ceph/src/pybind/mgr/bubbles/deploy
+    ./run-in-vagrant.sh
+```
 
 
 ### Step 3: Push image to local registry
@@ -174,7 +208,9 @@ First, we need to check a few bits of information:
 
  2. IP address for the host's `libvirt` network, because we will need to point
  the guest VMs to the local registry we deployed before. Typically this will be
- a `virbr` interface. We will be assuming it's `192.168.122.1`.
+ a `virbr` interface. You can easily find the ip by running
+ `ip addr | grep virbr0 | grep -o "[0-9\.]\{13\}" | head -1`.
+ We will be assuming it's `192.168.122.1`.
 
 Deploying a three node Ceph cluster, bootstrapped by `cephadm`, becomes a
 trivial task:

--- a/deploy/Vagrantfile
+++ b/deploy/Vagrantfile
@@ -1,0 +1,12 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "opensuse/Leap-15.2.x86_64"
+  config.vm.synced_folder "..", "/bubbles", type: "nfs"
+  config.vm.synced_folder "../../../../../", "/ceph", type: "nfs"
+  config.vm.provision "shell", inline: <<-SHELL
+#    cd /ceph/src/pybind/mgr/bubbles/deploy
+#    ./run-in-vagrant.sh
+  SHELL
+end

--- a/deploy/build-container.sh
+++ b/deploy/build-container.sh
@@ -36,11 +36,11 @@ mkdist() {
   mkdir dist
 
   pushd ../frontend
-  npm ci || exit 1
+  npm ci
   npx ng build \
     --output-hashing all \
     --configuration production \
-    --output-path ../deploy/dist/frontend/dist || exit 1
+    --output-path ../deploy/dist/frontend/dist
   popd
 
   pushd ..

--- a/deploy/dev-env.sh
+++ b/deploy/dev-env.sh
@@ -1,0 +1,99 @@
+#!/bin/bash -e
+
+exists(){
+  command -v "$1" >/dev/null 2>&1
+}
+
+step1_run_local_registry(){
+  registry_is_running=$(podman ps | grep "registry:2")
+  if [ -z "$registry_is_running" ]; then
+    registry=$HOME/local-bubbles-registry
+    mkdir -p $registry
+    podman run --privileged -d \
+            --name registry \
+            -p 5000:5000 \
+            -v $registry:/var/lib/registry \
+            --restart=always registry:2
+  fi
+}
+
+step2_build_container_image(){
+  if ! exists zypper; then
+    vagrant box update --force
+    vagrant up
+    vagrant ssh -c "cd /ceph/src/pybind/mgr/bubbles/deploy; ./run-in-vagrant.sh"
+    echo "Running script to load the image in 10 seconds"
+    sleep 10
+    ./load-image.sh
+    vagrant destroy -f
+  else
+    ./build-container.sh --force
+  fi
+}
+
+step3_push_to_local_registry(){
+  podman push \
+      --tls-verify=false \
+      localhost/opensuse/bubbles:master \
+      docker://127.0.0.1:5000/opensuse/bubbles:master
+}
+
+prepare_kcli(){
+  # Install kcli if not installed
+  if ! exists kcli; then
+      echo "kcli could not be found"
+      echo "(You need to have installed libvirt-dev or libvirt-devel in order for the installation to succeed)"
+      curl https://raw.githubusercontent.com/karmab/kcli/master/install.sh | bash
+  fi
+  # Copy id_rsa.pub into .kcli and add to /root/.ssh/authorized_keys if it does not exist
+  klcipub="$HOME/.kcli/id_rsa.pub"
+  if [ ! -f "$klcipub" ]; then
+    sshpub="$HOME/.ssh/id_rsa.pub"
+    cp $sshpub $klcipub
+    cat $sshpub | sudo tee -a /root/.ssh/authorized_keys > /dev/null
+  fi
+}
+
+step4_run_kcli(){
+  prepare_kcli
+  plan=bubbles
+  if [ -n "$(kcli list plan | grep $plan)" ]; then
+    sudo kcli delete plan $plan --yes
+  fi
+  sudo kcli create plan -f plan/cluster.yml -P ceph_dev_folder=$(readlink -v -f "../../../../../") -P registry=192.168.122.1:5000 $plan
+  echo "Run the following commands inside your first node:"
+  echo "sudo -s"
+  echo "cephadm shell"
+  echo "ceph mgr module enable bubbles"
+  echo "exit; ifconfig eth0 | grep 'inet ' | awk '{print \$2}'; exit; exit"
+  sudo kcli ssh ceph-node-00
+  echo "If everything works, Bubbles should be reachable on port 1337 on the above IP."
+}
+
+all_steps(){
+  step1_run_local_registry
+  step2_build_container_image
+  step3_push_to_local_registry
+  step4_run_kcli
+}
+
+image_was_build_and_added(){
+  step1_run_local_registry
+  step4_run_kcli
+}
+
+case "$1" in
+rebuild)
+    all_steps
+    ;;
+recreate)
+    image_was_build_and_added
+    ;;
+*)
+    echo "Usage: $0 <command>"
+    echo -e "\nAvailable commands:"
+    echo -e "  rebuild \t Build new image, add it to local registry and create a new bubbles cluster based on the new image"
+    echo -e "  recreate \t Create a new bubbles cluster based on the already build image"
+    echo -e "\nFor debugging run \"bash -x $0 <command>\""
+    exit 1
+esac

--- a/deploy/run-in-vagrant.sh
+++ b/deploy/run-in-vagrant.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Set storge conf as needed
+
+# Install everything that's needed
+sudo zypper in -y libvirt libvirt-devel podman buildah nodejs-common npm14
+curl https://raw.githubusercontent.com/karmab/kcli/master/install.sh | bash
+
+sudo sed -i 's/driver = ""/driver = "overlay"/' /etc/containers/storage.conf
+./build-container.sh --force
+if [ -z "$(sudo podman images | grep bubbles)" ]; then
+  echo "Image could not be created!"
+  echo "I will rerun the script now without clearing dist - mostly it works on the second time."
+  ./build-container.sh --skip-dist
+  if [ -z "$(sudo podman images | grep bubbles)" ]; then
+    echo "Image could still not be created!"
+    exit;
+  fi
+fi
+
+image=$(sudo podman images | grep bubbles)
+name=$(echo $image | awk '{print $1}')
+tag=$(echo $image | awk '{print $2}')
+imageId=$(echo $image | awk '{print $3}')
+saveName="bubbles-image.tar"
+scriptName="load-image.sh"
+
+if test -f "$saveName"; then
+  sudo rm $saveName
+fi
+sudo podman save -o $saveName $imageId
+
+cat <<EOF > $scriptName
+#!/bin/bash
+podman load -i $saveName
+podman tag $imageId $name:$tag
+EOF
+chmod +x $scriptName
+
+echo "Now run ./$scriptName to load the build image on the host."
+echo "Have a nice day \o/"
+sudo poweroff


### PR DESCRIPTION
There is a bug in openSUSE images which prevents zypper to run in non
priviledge containers, however if you use a SUSE distribution you can
run zypper with out an error on unpriviledged containers. To build
bubbles buildah is used, however the build commands for docker or podman
don't allow priviledged building, therefore the build script has to be
run inside a vagrant box based on a SUSE distribution in oder to run the
build successfully.

The bug is found here:
https://bugzilla.opensuse.org/show_bug.cgi?id=1190670

Signed-off-by: Stephan Müller <smueller@suse.com>