### PR TITLE
Set up dev enironment quickly with dev-env.sh

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -71,8 +71,8 @@ Therefore, the `id_rsa.pub` key used by `kcli` will need to be added to
 ### podman
 
 To build the container image and run the registry, we are going to need podman,
-which should be installed through whatever package repository and tool one's
-distro uses.
+which should be installed in version 3.4.x or higher through whatever package
+repository and tool one's distro uses.
 
 
 ### Ceph
@@ -94,6 +94,24 @@ the Ceph tree, such as
 But this is a matter of taste, and it really doesn't matter in the end.
 
 ## Deployment
+
+
+### Get started
+
+To run a cluster with a newly build image, run the following command and follow the instructions in the script:
+
+```
+    # ./dev-env.sh --rebuild
+```
+
+To recreate your cluster run the following command and follow the instructions in the script:
+
+```
+    # ./dev-env.sh --recreate
+```
+
+Continue reading to learn whats happening behind the scenes.
+
 
 ### How it works
 
@@ -149,7 +167,6 @@ Running `podman images` should now show a `localhost/opensuse/bubbles` image
 tagged with `master`. The name is relevant because that's the image name and
 tag we'll be pulling to deploy with `cephadm`.
 
-
 ### Step 3: Push image to local registry
 
 Because we are running an insecure registry, we will need to account for that
@@ -174,7 +191,9 @@ First, we need to check a few bits of information:
 
  2. IP address for the host's `libvirt` network, because we will need to point
  the guest VMs to the local registry we deployed before. Typically this will be
- a `virbr` interface. We will be assuming it's `192.168.122.1`.
+ a `virbr` interface. You can easily find the ip by running
+ `ip addr | grep virbr0 | grep -o "[0-9\.]\{13\}" | head -1`.
+ We will be assuming it's `192.168.122.1`.
 
 Deploying a three node Ceph cluster, bootstrapped by `cephadm`, becomes a
 trivial task:

--- a/deploy/dev-env.sh
+++ b/deploy/dev-env.sh
@@ -1,0 +1,114 @@
+#!/bin/bash -e
+
+CORRECT_PATH="src/pybind/mgr/bubbles/deploy"
+PATH_MSG="The script assumes that you run it inside your ceph clone from '$CORRECT_PATH'"
+
+usage() {
+  cat <<EOF
+Usage: $0 [option]
+
+options:
+  -b, --rebuild              Build new image and push it to your local registry
+                               before cluster creation
+  -c, --recreate             Create a new cluster based on the last build image
+
+Note:
+$PATH_MSG
+
+For debugging run "bash -x $0 [option]"
+EOF
+}
+
+exists(){
+  command -v "$1" >/dev/null 2>&1
+}
+
+check_path(){
+  if [ $(realpath --relative-to "../../../../../" ".") != $CORRECT_PATH ]; then
+    echo $PATH_MSG
+    exit 1
+  fi
+}
+
+step1_run_local_registry(){
+  registry_is_running=$(sudo podman ps | grep "registry:2" || :)
+  if [ -z "$registry_is_running" ]; then
+    sudo mkdir -p /var/lib/registry
+    ./run-registry.sh
+  fi
+}
+
+step2_build_container_image(){
+  ./build-container.sh --force --no-registry-tls --registry docker://127.0.0.1:5000
+}
+
+prepare_kcli(){
+  # Install kcli if not installed
+  if ! exists kcli; then
+    echo "kcli could not be found"
+    echo "(You need to have installed libvirt-dev or libvirt-devel in order for the installation to succeed)"
+    curl https://raw.githubusercontent.com/karmab/kcli/master/install.sh | bash
+  fi
+  # Copy id_rsa.pub into .kcli and add to /root/.ssh/authorized_keys if it does not exist
+  klcipub="$HOME/.kcli/id_rsa.pub"
+  if [ ! -f "$klcipub" ]; then
+    sshpub="$HOME/.ssh/id_rsa.pub"
+    cp $sshpub $klcipub
+    cat $sshpub | sudo tee -a /root/.ssh/authorized_keys > /dev/null
+  fi
+}
+
+step3_run_kcli(){
+  prepare_kcli
+  plan=bubbles
+  if [ -n "$(kcli list plan | grep $plan)" ]; then
+    kcli delete plan $plan --yes
+  fi
+  kcli create plan -f plan/cluster.yml -P ceph_dev_folder=$(readlink -v -f "../../../../../") -P registry=docker://127.0.0.1:5000 $plan
+  cat <<EOF
+You have now accessed your first node of your cluster.
+
+Run the following commands inside it:
+# sudo -s
+
+Try to run the following command, if it couldn't be found, try again a minute later, it will come up:
+$ cephadm shell
+
+Inside cephadm run:
+#$ ceph -s
+If the status looks good enable Bubbles as mgr module with:
+#$ ceph mgr module enable bubbles
+Recheck the status of your cluster if everything is fine, you can exit the cephadm shell.
+
+Get the IP of the node:
+# ifconfig eth0 | grep 'inet ' | awk '{print \$2}'
+If everything works, Bubbles can be reached from the outside on port 1337 of your node."
+
+EOF
+  kcli ssh ceph-node-00
+}
+
+all_steps(){
+  check_path
+  step1_run_local_registry
+  step2_build_container_image
+  step3_run_kcli
+}
+
+image_was_build_and_added(){
+  check_path
+  step1_run_local_registry
+  step3_run_kcli
+}
+
+case "$1" in
+  -b|--rebuild)
+    all_steps
+    ;;
+  -c|--recreate)
+    image_was_build_and_added
+    ;;
+  *)
+    usage
+    exit 0
+esac


### PR DESCRIPTION
With the dev-env.sh you can easily setup your cluster with a newly build
image or the last build image.

It also provides the info to use podman in 3.4.x as this overcomes the
zypper container bug (https://bugzilla.opensuse.org/show_bug.cgi?id=1190670),
you encouter on older versions as the newer version provides building
containers with the priviledged flag.

Signed-off-by: Stephan Müller <smueller@suse.com>